### PR TITLE
Deps: Upgrade Go Version to 1.23

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,16 +23,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set Go version
-        id: go_version
-        run: |
-          GO_VERSION=$(sed -E -n '/^go / s/^go ([0-9]+\.[0-9]+)(\.[0-9]+)?$/\1/p' < go.mod)
-          echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ steps.go_version.outputs.version }}
+          go-version-file: go.mod
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set Go version
-        id: go_version
-        run: |
-          GO_VERSION=$(sed -E -n '/^go / s/^go ([0-9]+\.[0-9]+)(\.[0-9]+)?$/\1/p' < go.mod)
-          echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ steps.go_version.outputs.version }}
+          go-version-file: go.mod
           cache: true
 
       - name: Setup pnpm

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module inbox451
 
-go 1.22.0
-
-toolchain go1.22.8
+go 1.23
 
 require (
 	github.com/emersion/go-imap v1.2.1


### PR DESCRIPTION
- In GH Actions we removed the step to manually set the Go version and instead configured the `setup-go` action to use the `go-version-file` parameter pointing to `go.mod`
- Updated the Go version from `1.22.0` to `1.23` and removed the `toolchain` directive as we now don't care about the patch version