### PR TITLE
chore: Add CODEOWNERS file with default owners for pull requests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. They will be requested for review when someone
+# opens a pull request.
+*       @inbox451/inbox451-maintainers


### PR DESCRIPTION
This pull request includes the `CODEOWNERS` file. The change assigns the `@inbox451/inbox451-maintainers` team as the default owners for everything in the repository, ensuring they are requested for review when someone opens a pull request.