### PR TITLE
feat: add configurable email domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ EXPOSE 8080 1025 1143
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost${INBOX451_SERVER_HTTP_PORT}/api/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost${INBOX451_SERVER_HTTP_PORT}/api/health || exit 1
 
 # Run the application
 ENTRYPOINT ["./inbox451"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ server:
   imap:
     port: ":1143"
     hostname: "localhost"
+  email_domain: "example.com"
 database:
   url: "postgres://inbox:inbox@localhost:5432/inbox451?sslmode=disable"
 logging:

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -9,6 +9,7 @@ server:
   imap:
     port: ":1143"
     hostname: "localhost"
+  email_domain: "example.com"
 database:
   url: "postgres://inbox:inbox@localhost:5432/inbox451?sslmode=disable"
   max_open_conns: 25

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ x-environment: &shared-environment
   POSTGRES_DB: ${POSTGRES_DB:-inbox451}
   POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
   POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+  INBOX451_SERVER_EMAIL_DOMAIN: ${INBOX451_SERVER_EMAIL_DOMAIN:-example.com}
 
 services:
   postgres:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -57,7 +57,7 @@ func NewServer(ctx context.Context, core *core.Core, db *sql.DB) *Server {
 		AllowMethods:     []string{http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete, http.MethodOptions},
 		AllowHeaders:     []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderAuthorization},
 		AllowCredentials: true, // Required when sending cookies/credentials
-		MaxAge:           86400, 
+		MaxAge:           86400,
 	}))
 	e.Use(echomiddleware.RequestID())
 	e.Use(echomiddleware.Secure())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 			Port     string `koanf:"port"`
 			Hostname string `koanf:"hostname"`
 		}
+		EmailDomain string `koanf:"email_domain"`
 	} `koanf:"server"`
 	Database DatabaseConfig `koanf:"database"`
 	Logging  struct {

--- a/internal/smtp/server_test.go
+++ b/internal/smtp/server_test.go
@@ -1,0 +1,115 @@
+package smtp
+
+import (
+	"io"
+	"testing"
+
+	"inbox451/internal/config"
+	"inbox451/internal/core"
+	"inbox451/internal/logger"
+	"inbox451/internal/mocks"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func setupSMTPTestCore(t *testing.T) (*core.Core, *mocks.Repository) {
+	mockRepo := mocks.NewRepository(t)
+	logger := logger.New(io.Discard, logger.DEBUG)
+
+	core := &core.Core{
+		Config:     &config.Config{},
+		Logger:     logger,
+		Repository: mockRepo,
+	}
+
+	// Set default SMTP port
+	core.Config.Server.SMTP.Port = ":1025"
+
+	return core, mockRepo
+}
+
+func TestNewServer_EmailDomainConfiguration(t *testing.T) {
+	tests := []struct {
+		name         string
+		emailDomain  string
+		smtpHostname string
+		expectDomain string
+		expectLog    string
+	}{
+		{
+			name:         "EmailDomain takes precedence over SMTP.Hostname",
+			emailDomain:  "mail.example.com",
+			smtpHostname: "smtp.example.com",
+			expectDomain: "mail.example.com",
+			expectLog:    "SMTP server domain set to:",
+		},
+		{
+			name:         "Falls back to SMTP.Hostname when EmailDomain is empty",
+			emailDomain:  "",
+			smtpHostname: "smtp.example.com",
+			expectDomain: "smtp.example.com",
+			expectLog:    "EmailDomain not configured, falling back to SMTP.Hostname:",
+		},
+		{
+			name:         "Warning when both are empty",
+			emailDomain:  "",
+			smtpHostname: "",
+			expectDomain: "",
+			expectLog:    "Neither EmailDomain nor SMTP.Hostname configured",
+		},
+		{
+			name:         "Uses EmailDomain when set",
+			emailDomain:  "example.com",
+			smtpHostname: "",
+			expectDomain: "example.com",
+			expectLog:    "SMTP server domain set to:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, _ := setupSMTPTestCore(t)
+			core.Config.Server.EmailDomain = tt.emailDomain
+			core.Config.Server.SMTP.Hostname = tt.smtpHostname
+
+			server := NewServer(core)
+			assert.NotNil(t, server)
+			assert.Equal(t, tt.expectDomain, server.smtp.Domain)
+		})
+	}
+}
+
+func TestSmtpServer_Integration(t *testing.T) {
+	tests := []struct {
+		name        string
+		emailDomain string
+		setupCore   func(*core.Core)
+	}{
+		{
+			name:        "Server starts with EmailDomain configured",
+			emailDomain: "test.example.com",
+			setupCore: func(c *core.Core) {
+				c.Config.Server.EmailDomain = "test.example.com"
+			},
+		},
+		{
+			name:        "Server starts without EmailDomain",
+			emailDomain: "",
+			setupCore: func(c *core.Core) {
+				c.Config.Server.SMTP.Hostname = "smtp.example.com"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, _ := setupSMTPTestCore(t)
+			tt.setupCore(core)
+
+			server := NewServer(core)
+			assert.NotNil(t, server)
+			assert.NotNil(t, server.smtp)
+			assert.Equal(t, ":1025", server.smtp.Addr)
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces support for configuring an `EmailDomain` for the server, which is used to validate and format email addresses in the application. It includes changes to configuration files, core logic, and test cases to ensure proper handling of the new feature. The most important changes are grouped below:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a default email domain for inbox creation and updates. If configured, emails without a domain will automatically use the specified domain, and validation ensures emails match the configured domain.
  - SMTP server now prioritizes the configured email domain for its hostname, with improved fallback and informative logging.

- **Bug Fixes**
  - Corrected minor formatting and whitespace issues in configuration and Docker files.

- **Documentation**
  - Updated sample configuration and README to include the new email domain option.

- **Tests**
  - Added comprehensive tests for email domain handling in inbox operations and SMTP server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->